### PR TITLE
Updated readme and manifests to follow the puppetlabs style-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Daemonization is currently achieved through a modified version of the Yeasoft bt
 Install Syncthing, the service (init.d script) with default paths, no instances:
 
 ```puppet
-    class { 'syncthing':  }
+class { 'syncthing': }
 ```
 
 ###Syncthing instances
@@ -45,31 +45,31 @@ Instances can be declared directly in the Syncthing base class, or by defined ty
 
 ```puppet
 class { '::syncthing':
-    instances   => {
-        'example'   => {
-            home_path      => '/home/synctester/example_instance',
-            daemon_uid     => 'synctest', // Default: root
-            daemon_gid     => 'synctester', // Default: root
-            
-            // Variables for standard parameters
-            gui_tls        => true,
-            gui_address    => '0.0.0.0', // (Default)
-            gui_port       => '8888', // Default: 8080
+  instances => {
+    'example' => {
+      home_path   => '/home/synctester/example_instance',
+      daemon_uid  => 'synctest', // Default: root
+      daemon_gid  => 'synctester', // Default: root
 
-            // Override or set arbitrary options
-            options        => {
-                'listenAddress'   => '0.0.0.0:19000',
-                'startBrowser'    => 'false',
-            },
-        }
+      // Variables for standard parameters
+      gui_tls     => true,
+      gui_address => '0.0.0.0', // (Default)
+      gui_port    => '8888', // Default: 8080
+
+      // Override or set arbitrary options
+      options     => {
+        'listenAddress' => '0.0.0.0:19000',
+        'startBrowser'  => 'false',
+      },
     }
+  }
 }
 ```
 or:
 ```puppet
 ::syncthing::instance { 'example':
-    home_path      => '/home/synctester/example_instance',
-    ...
+  home_path => '/home/synctester/example_instance',
+  ...
 }
 ```
 
@@ -185,11 +185,11 @@ Override the default value passed to `syncthing::device` for `options`.
 Creates an instance. Provides some parameters for common options and an `options` parameter to override or set arbitrary options.
 
 ```puppet
-    syncthing::instance { 'example':
-        home_path      => '/etc/backups/example',
-        daemon_uid     => 'user',
-        gui_tls        => true,
-    }
+  syncthing::instance { 'example':
+    home_path  => '/etc/backups/example',
+    daemon_uid => 'user',
+    gui_tls    => true,
+  }
 ```
 
 **Parameters within `syncthing::instance`:**
@@ -262,11 +262,11 @@ Set or override arbitrary options. Created as XML nodes in the `<options></optio
 Adds a `<device>` entry to the configuration file for the instance associated with the passed home path.
 
 ```puppet
-    ::syncthing::device { 'laptop':
-	    home_path    => '/etc/backup/instance1',
-	    id           => '523LMDC-KKQPKVU-JBPGYQU-IAGHP5B-TU38GN4-G7CEEHG-OOL32IR-YWQSFAX',
-	    compression  => true,
-    }
+  ::syncthing::device { 'laptop':
+    home_path   => '/etc/backup/instance1',
+    id          => '523LMDC-KKQPKVU-JBPGYQU-IAGHP5B-TU38GN4-G7CEEHG-OOL32IR-YWQSFAX',
+    compression => true,
+  }
 ```
 
 **Parameters within `syncthing::device`:**
@@ -308,17 +308,17 @@ Set or override arbitrary options. Created as XML nodes in the `<device></device
 Adds a `<folder>` entry to the configuration file for the instance associated with the passed home path.
 
 ```puppet
-    ::syncthing::folder { 'laptop':
-	    home_path    => '/etc/backup/instance1',
-	    id           => 'backupfolder1',
-	    path         => '/home/syncuser/myfiles',
-		options      => {
-			# Override options here
-		},
-		devices      => {
-			'523LMDC-KKQPKVU-JBPGYQU-IAGHP5B-TU38GN4-G7CEEHG-OOL32IR-YWQSFAX' => 'present',
-		}
-    }
+::syncthing::folder { 'laptop':
+  home_path => '/etc/backup/instance1',
+  id        => 'backupfolder1',
+  path      => '/home/syncuser/myfiles',
+  options   => {
+    # Override options here
+  },
+  devices   => {
+    '523LMDC-KKQPKVU-JBPGYQU-IAGHP5B-TU38GN4-G7CEEHG-OOL32IR-YWQSFAX' => 'present',
+  }
+}
 ```
 
 **Parameters within `syncthing::folder`:**
@@ -360,14 +360,14 @@ Set or override arbitrary options. Created as XML nodes in the `<folder></folder
 A hash of devices to enable for the folder. Invididual device IDs can be specified and set to `present` or `absent`:
 
 ```puppet
-    ::syncthing::folder { 'laptop':
-	    ...
-		devices      => {
-			'523LMDC-KKQPKVU-JBPGYQU-IAGHP5B-TU38GN4-G7CEEHG-OOL32IR-YWQSFAX' => 'present',
-			'IAGHP5B-7IASKM-JBPGYQU-G7CEEHG-TU38GN4-TU38GN4-523LMDC-OOL32IR' => 'absent',
-		}
-		...
-    }
+::syncthing::folder { 'laptop':
+  ...
+  devices => {
+    '523LMDC-KKQPKVU-JBPGYQU-IAGHP5B-TU38GN4-G7CEEHG-OOL32IR-YWQSFAX' => 'present',
+    'IAGHP5B-7IASKM-JBPGYQU-G7CEEHG-TU38GN4-TU38GN4-523LMDC-OOL32IR'  => 'absent',
+  }
+  ...
+}
 ```
 
 ####Defined Type: `syncthing::folder_device`
@@ -375,11 +375,11 @@ A hash of devices to enable for the folder. Invididual device IDs can be specifi
 Adds a `<device>` entry for the specified folder.
 
 ```puppet
-    ::syncthing::folder { 'laptop_on_backupfolder1':
-	    home_path    => '/etc/backup/instance1',
-	    folder_id    => 'backupfolder1',
-	    device_id    => '523LMDC-KKQPKVU-JBPGYQU-IAGHP5B-TU38GN4-G7CEEHG-OOL32IR-YWQSFAX',
-    }
+::syncthing::folder { 'laptop_on_backupfolder1':
+  home_path => '/etc/backup/instance1',
+  folder_id => 'backupfolder1',
+  device_id => '523LMDC-KKQPKVU-JBPGYQU-IAGHP5B-TU38GN4-G7CEEHG-OOL32IR-YWQSFAX',
+}
 ```
 
 **Parameters within `syncthing::folder_device`:**

--- a/manifests/device.pp
+++ b/manifests/device.pp
@@ -26,16 +26,16 @@ define syncthing::device
   }
 
   augeas { "configure instance ${home_path} device ${id}": 
-    incl       => $instance_config_xml_path,
-    lens       => 'Xml.lns',
-    context    => "/files${instance_config_xml_path}/configuration",
-    changes    => $changes,
+    incl    => $instance_config_xml_path,
+    lens    => 'Xml.lns',
+    context => "/files${instance_config_xml_path}/configuration",
+    changes => $changes,
     
-    notify      => [
+    notify  => [
       Service['syncthing'],
     ],
     
-    require     => [
+    require => [
       Class['syncthing'],
     ],
   }

--- a/manifests/folder.pp
+++ b/manifests/folder.pp
@@ -29,16 +29,16 @@ define syncthing::folder
   }
 
   augeas { "configure instance ${home_path} folder ${id}": 
-    incl       => $instance_config_xml_path,
-    lens       => 'Xml.lns',
-    context    => "/files${instance_config_xml_path}/configuration",
-    changes    => $changes,
+    incl    => $instance_config_xml_path,
+    lens    => 'Xml.lns',
+    context => "/files${instance_config_xml_path}/configuration",
+    changes => $changes,
     
-    notify      => [
+    notify  => [
       Service['syncthing'],
     ],
     
-    require     => [
+    require => [
       Class['syncthing'],
     ],
   }

--- a/manifests/folder_device.pp
+++ b/manifests/folder_device.pp
@@ -21,16 +21,16 @@ define syncthing::folder_device
   }
 
   augeas { "configure instance ${home_path} folder ${folder_id} device ${device_id}": 
-    incl        => $instance_config_xml_path,
-    lens        => 'Xml.lns',
-    context     => "/files${instance_config_xml_path}/configuration",
-    changes     => $changes,
+    incl    => $instance_config_xml_path,
+    lens    => 'Xml.lns',
+    context => "/files${instance_config_xml_path}/configuration",
+    changes => $changes,
     
-    notify      => [
+    notify  => [
       Service['syncthing'],
     ],
     
-    require     => [
+    require => [
       Class['syncthing'],
     ],
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,32 +1,30 @@
-class syncthing::install
-(
-)
-{
+class syncthing::install {
+
   case $::operatingsystem {
-      Debian: {
-			  file { $syncthing::binpath:
-			    ensure        => directory,
-			    owner         => root,
-			    group         => root,
-			    mode          => '0755',
-			  }
-			  ->
-			  exec { "download and unpack syncthing":
-			    cwd         => $syncthing::binpath,
-			    command     => "wget -O - https://github.com/syncthing/syncthing/releases/download/v${syncthing::version}/syncthing-linux-amd64-v${syncthing::version}.tar.gz | tar xzf - --strip-components=1 syncthing-linux-amd64-v${syncthing::version}/syncthing",
-			    creates     => "${syncthing::binpath}/${syncthing::bin}",
-			    path        => $::path,
-			  }
+    Debian: {
+      file { $syncthing::binpath:
+        ensure => 'directory',
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0755',
+      }->
+      exec { "download and unpack syncthing":
+        cwd     => $syncthing::binpath,
+        command => "wget -O - https://github.com/syncthing/syncthing/releases/download/v${syncthing::version}/syncthing-linux-amd64-v${syncthing::version}.tar.gz | tar xzf - --strip-components=1 syncthing-linux-amd64-v${syncthing::version}/syncthing",
+        creates => "${syncthing::binpath}/${syncthing::bin}",
+        path    => $::path,
       }
-      Ubuntu: {
-        apt::ppa { 'ppa:ytvwld/syncthing': }
-        ->
-        package { 'syncthing':
-          ensure    => $syncthing::version,
-        }
+    }
+    Ubuntu: {
+      apt::ppa { 'ppa:ytvwld/syncthing': }
+      ->
+      package { 'syncthing':
+        ensure => $syncthing::version,
       }
-      default: {
-          fail "Unsupported Operating System: ${::operatingsystem}"
-      }
+    }
+    default: {
+        fail "Unsupported Operating System: ${::operatingsystem}"
+    }
   }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,4 @@
-class syncthing::params
-(
-)
-{
+class syncthing::params {
   $binpath                = '/usr/bin'
 
   $bin                    = 'syncthing'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,44 +1,40 @@
-class syncthing::service
-(
-)
-{
+class syncthing::service {
+
   if ! defined(Class['syncthing']) {
     fail('You must include the syncthing base class before using any syncthing defined resources')
   }
-  
+
   file { '/etc/default/syncthing':
-    content     => template('syncthing/default.erb'),
-    owner       => 'root',
-    group       => 'root',
-    mode        => '0744',
+    content => template('syncthing/default.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0744',
   }
-    
+
   file { $::syncthing::instancespath:
-    ensure      => directory,
-    owner       => 'root',
-    group       => 'root',
-    mode        => '0755',
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
   }
-    
+
   file { '/etc/init.d/syncthing':
-    content     => template('syncthing/init.d.erb'),
-    owner       => 'root',
-    group       => 'root',
-    mode        => '0755',
-    
-    require     => [
-		  File['/etc/default/syncthing'],
-		  File[$::syncthing::instancespath],
-		],
+    content => template('syncthing/init.d.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    require => [
+      File['/etc/default/syncthing'],
+      File[$::syncthing::instancespath],
+    ],
   }
-  
+
   service { 'syncthing':
     ensure  => running,
     enable  => true,
-    
     require => [
       File['/etc/init.d/syncthing']
     ],
   }
-  
+
 }


### PR DESCRIPTION
This commit removes tabs and makes spacing consistent. It also aligns arrows per the style guide.
https://docs.puppetlabs.com/guides/style_guide.html
