### PR TITLE
Allow to specify a different package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Override the value used for the installation. Defaults to `latest`, in which cas
 Boolean to install syncthing APT repository. Defaults to `true`.
 Set it to `false` to control package installation using your internal / personal repository.
 
+#####`package_name`
+
+The name of the package that will be used for syncthing installation. Defaults to `syncthing`.
+Nice option for those we built their own packages.
+
 #####`kernel`
 
 Override the kernel parameter determined via Facter. Used in determining the download URL for Syncthing.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Override the architecture parameter determined via Facter. Used in determining t
 
 Override the value used for the installation. Defaults to `latest`, in which case new releases will be downloaded when they are publishing on the Syncthing Github page. Note that Syncthing also has an auto-update mechanism.
 
+#####`manage_repo`
+
+Boolean to install syncthing APT repository. Defaults to `true`.
+Set it to `false` to control package installation using your internal / personal repository.
+
 #####`kernel`
 
 Override the kernel parameter determined via Facter. Used in determining the download URL for Syncthing.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@ class syncthing
   $instancespath      = $::syncthing::params::instancespath,
   $version            = $::syncthing::params::version,
   $manage_repo        = $::syncthing::params::manage_repo,
+  $package_name       = $::syncthing::params::package_name,
 
   $instances          = $::syncthing::params::default_instances,
   $devices            = $::syncthing::params::default_devices,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,5 @@
 class syncthing::install {
-  package { 'syncthing':
+  package { $::syncthing::package_name:
     ensure  => $::syncthing::version,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,8 +3,9 @@ class syncthing::params {
   $instancespath          = '/etc/syncthing'
 
   $version                = 'latest'
-  
+
   $manage_repo            = true
+  $package_name           = 'syncthing'
 
   $default_instances      = {}
   $default_devices        = {}

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,7 +18,7 @@ class syncthing::repo {
             include_src => false,
             require     => Apt::Key[$release_key],
             before      => [
-              Package['syncthing'],
+              Package[$::syncthing::package_name],
             ]
           }
       }


### PR DESCRIPTION
Hello,
Related to #3. Support those who built their own packages combined with `manage_repo` attribute.
