### PR TITLE
Use sudo instead of su

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -56,7 +56,7 @@ define syncthing::instance
 
     exec { "create syncthing instance ${name} home":
       path     => $::path,
-      command  => "su - ${daemon_uid} -c \"${syncthing::binpath} -generate \\\"${home_path}\\\"\"",
+      command  => "sudo -u ${daemon_uid} ${syncthing::binpath} -generate \"${home_path}\"",
       creates  => $instance_config_xml_path,
       provider => shell,
 


### PR DESCRIPTION
This change uses sudo instead of su. I made because in my system su does not work because the user does not have a valid shell. With sudo you don't need a valid shell to run a command.
Besides this, I thing that sudo is a better option than su.
