### PR TITLE
Add trailing slash to path in folder node

### DIFF
--- a/templates/config_folder-changes.yaml.erb
+++ b/templates/config_folder-changes.yaml.erb
@@ -1,6 +1,6 @@
 ---
  - 'set folder[#attribute/id="<%= @id %>"]/#attribute/id <%= @id %>'
- - 'set folder[#attribute/id="<%= @id %>"]/#attribute/path <%= @path %>'
+ - 'set folder[#attribute/id="<%= @id %>"]/#attribute/path <%= @path.sub(/(\/*\Z)/, '/') %>'
  - 'set folder[#attribute/id="<%= @id %>"]/#attribute/ro <%= @ro %>'
  - 'set folder[#attribute/id="<%= @id %>"]/#attribute/rescanIntervalS <%= @rescanIntervalS %>'
  - 'set folder[#attribute/id="<%= @id %>"]/#attribute/ignorePerms <%= @ignorePerms %>'


### PR DESCRIPTION
Because we want to get as close to config generated by syncthing
as possible, we should add this slash, as syncthing does the same.
