### PR TITLE
Fix empty label augeas error

### DIFF
--- a/manifests/folder.pp
+++ b/manifests/folder.pp
@@ -6,7 +6,7 @@ define syncthing::folder
 
   # Path to the folder
   $path,
-  $label            = '',
+  $label            = $name,
 
   $ensure           = 'present',
 


### PR DESCRIPTION
If we do not specify label for device, augeas will try to set it
to empty string and it will fail, because you can't set empty
attribute using augeas.

This patch will make a default label same as device resource name.

This commit closes #18.
