### PR TITLE
Added environment parameter on Exec['create syncthing instance']

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -113,12 +113,15 @@ define syncthing::instance
     }
 
     exec { "create syncthing instance ${home_path}":
-      path     => $::path,
-      command  => "sudo -u ${daemon_uid} ${syncthing::binpath} -generate \"${home_path}\"",
-      creates  => $instance_config_xml_path,
-      provider => shell,
+      path        => $::path,
+      command     => "${syncthing::binpath} -generate \"${home_path}\"",
+      environment => [ 'STNODEFAULTFOLDER=1', 'HOME=$HOME' ],
+      user        => $daemon_uid,
+      group       => $daemon_gid,
+      creates     => $instance_config_xml_path,
+      provider    => shell,
 
-      notify   => [
+      notify      => [
 #        Service["syncthing ${name}"],
         Exec["restart syncthing instance ${name}"],
       ],


### PR DESCRIPTION
Environment variable STNODEFAULTFOLDER added to avoid creation of default folder when running exec create syncthing instance.

Command has been converted from sudo to a simple call to syncthing binary using UID and GID provided. As a result of this HOME is needed to be added as environment variable.
