### PR TITLE
Apt update before package installation

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -23,6 +23,7 @@ class syncthing::repo {
               Package[$::syncthing::package_name],
             ],
           }
+          Class['apt::update'] -> Package[$::syncthing::package_name]
       }
       default: {
           fail "Unsupported OS family: ${::osfamily}"


### PR DESCRIPTION
Hello

This commit fixes an ordering violation.
In particular, executing `apt-update` must precede package installation.
This is the console output confirming this ordering violation.

```
Notice: /Stage[main]/Syncthing::Install_package/Package[syncthing]/ensure: current_value purged, should be latest (noop)
Notice: Class[Syncthing::Install_package]: Would have triggered 'refresh' from 1 events
Notice: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]/ensure: current_value absent, should be file (noop)
Notice: Apt::Setting[conf-update-stamp]: Would have triggered 'refresh' from 1 events
Notice: Class[Apt::Update]: Would have triggered 'refresh' from 3 events
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Would have triggered 'refresh' from 1 events
Notice: Class[Apt::Update]: Would have triggered 'refresh' from 1 events
```

More details in the official documentation of puppetlabs-apt:
https://github.com/puppetlabs/puppetlabs-apt#adding-new-sources-or-ppas

> If you are adding a new source and trying to install packagesfrom the new source on the same Puppet run, your package resourceshould depend on Class[’apt::update’], as well as depending on theApt::Source resource”